### PR TITLE
Issue #12: add all_dir_paths

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -16,28 +16,26 @@ Release History
   Previously, directories were only emitted when walked by the underling
   iterator, which resulted in paths being missed in some cases.
 
-* *SEMANTIC CHANGE*: to implement some of the fixes noted below, the
-  ``dir_paths`` iterator has been updated to emit paths in the following
-  order for each directory produced by the underling iterator:
-
-    * given directory if it appears to be a new root directory (i.e. it is
-      not a subdirectory of the current root directory)
-    * subdirectories of the given directory
-
-  Previously, directories were only emitted when walked by the underling
-  iterator, which resulted in paths being missed in some cases.
-
 * Thanks go to Aviv Palivoda for being the driving force behind this release,
   especially in addressing a variety of issues in the way directory filtering
   and symlinks to directories are handled.
 
-* Issue #3: ``all_paths`` and ``dir_paths`` now correctly report symlinks to
-  directories as directory paths, even when ``followlinks`` is disabled in
-  the underlying iterator (fix contributed by Aviv Palivoda)
+* Issue #12: a new API, ``all_dir_paths`` has been added which, in addition to
+  the directories visited by the underlying walk, also emits:
 
-* Issue #4: ``all_paths`` and ``dir_paths`` now correctly report subdirectories
-  at the maximum depth when the ``limit_depth`` filter is used to trim nested
-  subdirectories (fix contributed by Aviv Palivoda)
+    * symlinks to directories when ``followlinks`` is disabled in the
+      underlying iterator
+    * subdirectories of leaf directories when the directory tree depth of
+      the underlying iterator has been limited (for example, with the
+      ``limit_depth`` filter)
+
+* Issue #3: ``all_paths`` now correctly reports symlinks to directories as
+  directory paths, even when ``followlinks`` is disabled in the underlying
+  iterator (fix contributed by Aviv Palivoda)
+
+* Issue #4: ``all_paths`` now correctly reports subdirectories at the maximum
+  depth when the ``limit_depth`` filter is used to trim nested subdirectories
+  (fix contributed by Aviv Palivoda)
 
 * Issue #6: ``min_depth``, ``all_paths``, ``dir_paths``, and ``file_paths``
   all now work correctly with ``os.fwalk`` and other underlying iterators
@@ -45,8 +43,8 @@ Release History
   (fix contributed by Aviv Palivoda)
 
 * Issue #7: all filters now explicitly indicate in their documentation whether
-  or not they support being used with bottom-up/depth-first traversal of the
-  underlying directory hierarchy
+  or not they support being used with bottom-up traversal of the underlying
+  directory hierarchy
 
 * A temporary generated filesystem is now used to test symlink loop handling
   and other behaviours that require a real filesystem (patch contributed by

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ The module is designed so that all purely filtering operations *preserve*
 the output of the underlying iterable. This means that named tuples, tuples
 containing more than 3 values (such as those produced by :func:`os.fwalk`),
 and objects that aren't tuples at all but are still defined such that
-``x[0], x[1], x[2] => dirpath, subdirs, files`` can be filtered without being
+``x[0], x[1], x[2] => dirpath, subdirs, files``, can be filtered without being
 converted to ordinary 3-tuples.
 
 .. versionchanged:: 0.3
@@ -33,17 +33,26 @@ converted to ordinary 3-tuples.
 Path Iteration
 --------------
 
-Three iterators are provided for iteration over filesystem paths:
-
-.. autofunction:: all_paths
-
-.. autofunction:: dir_paths
+Four iterators are provided for iteration over filesystem paths:
 
 .. autofunction:: file_paths
 
-Except when the underlying iterable switches to a new root directory, these
-functions yield subdirectory paths when visiting the parent directory, rather
-than when visiting the subdirectory.
+.. autofunction:: dir_paths
+
+.. autofunction:: all_dir_paths
+
+   .. versionadded:: 0.4
+
+.. autofunction:: all_paths
+
+   .. versionchanged:: 0.4
+      This function now combines the output of :func:`file_paths` with that
+      of :func:`all_dir_paths` (previously it was the combination of
+      :func:`file_paths` with :func:`dir_paths`)
+
+Except when the underlying iterable switches to a new root directory, the last
+two functions yield subdirectory paths when visiting the parent directory,
+rather than when visiting the subdirectory.
 
 For example, given the following directory tree::
 
@@ -75,6 +84,17 @@ For example, given the following directory tree::
     test/test4/file1.txt
     test/test4/test5
 
+``all_dir_paths`` will produce::
+
+    >>> from walkdir import filtered_walk, all_dir_paths
+    >>> paths = all_dir_paths(filtered_walk('test'))
+    >>> print('\n'.join(paths))
+    test
+    test/test2
+    test/test4
+    test/test2/test3
+    test/test4/test5
+
 ``dir_paths`` will produce::
 
     >>> from walkdir import filtered_walk, dir_paths
@@ -82,9 +102,10 @@ For example, given the following directory tree::
     >>> print('\n'.join(paths))
     test
     test/test2
-    test/test4
     test/test2/test3
+    test/test4
     test/test4/test5
+
 
 And ``file_paths`` will produce::
 

--- a/walkdir.py
+++ b/walkdir.py
@@ -41,8 +41,8 @@ def include_dirs(walk_iter, *include_filters):
     Inclusion filters are passed directly as arguments.
 
     This filter works by modifying the subdirectory lists produced by the
-    underlying iterator, and hence requires a top-down/breadth-first
-    traversal of the directory hierarchy.
+    underlying iterator, and hence requires a top-down traversal of the
+    directory hierarchy.
     """
     filter_subdirs = _make_include_filter(include_filters)
     for dir_entry in walk_iter:
@@ -56,8 +56,8 @@ def include_files(walk_iter, *include_filters):
     Inclusion filters are passed directly as arguments
 
     This filter does not modify the subdirectory lists produced by the
-    underlying iterator, and hence supports both top-down/breadth-first
-    and bottom-up/depth-first traversal of the directory hierarchy.
+    underlying iterator, and hence supports both top-down and bottom-up
+    traversal of the directory hierarchy.
     """
     filter_files = _make_include_filter(include_filters)
     for dir_entry in walk_iter:
@@ -90,8 +90,8 @@ def exclude_dirs(walk_iter, *exclude_filters):
     Exclusion filters are passed directly as arguments
 
     This filter works by modifying the subdirectory lists produced by the
-    underlying iterator, and hence requires a top-down/breadth-first
-    traversal of the directory hierarchy.
+    underlying iterator, and hence requires a top-down traversal of the
+    directory hierarchy.
     """
     filter_subdirs = _make_exclude_filter(exclude_filters)
     for dir_entry in walk_iter:
@@ -105,8 +105,8 @@ def exclude_files(walk_iter, *exclude_filters):
     Exclusion filters are passed directly as arguments
 
     This filter does not modify the subdirectory lists produced by the
-    underlying iterator, and hence supports both top-down/breadth-first
-    and bottom-up/depth-first traversal of the directory hierarchy.
+    underlying iterator, and hence supports both top-down and bottom-up
+    traversal of the directory hierarchy.
     """
     filter_files = _make_exclude_filter(exclude_filters)
     for dir_entry in walk_iter:
@@ -128,8 +128,8 @@ def limit_depth(walk_iter, depth):
     reference point.
 
     This filter works by modifying the subdirectory lists produced by the
-    underlying iterator, and hence requires a top-down/breadth-first
-    traversal of the directory hierarchy.
+    underlying iterator, and hence requires a top-down traversal of the
+    directory hierarchy.
     """
     if depth < 0:
         msg = "Depth limit less than 0 ({!r} provided)"
@@ -186,8 +186,8 @@ def min_depth(walk_iter, depth):
       as ``itertools.chain(os.walk("test/test2"), os.walk("test/test4")).``
 
     This filter works by modifying the subdirectory lists produced by the
-    underlying iterator, and hence requires a top-down/breadth-first
-    traversal of the directory hierarchy.
+    underlying iterator, and hence requires a top-down traversal of the
+    directory hierarchy.
     """
     if depth < 1:
         msg = "Minimium depth less than 1 ({!r} provided)"
@@ -217,7 +217,7 @@ def handle_symlink_loops(walk_iter, onloop=None):
 
     This filter skips processing subdirectories by modifying the subdirectory
     lists produced by the underlying iterator, and hence requires a
-    top-down/breadth-first traversal of the directory hierarchy.
+    top-down traversal of the directory hierarchy.
     """
     if onloop is None:
         def onloop(dirpath):
@@ -316,13 +316,34 @@ def filtered_walk(top, included_files=None, included_dirs=None,
 
 
 # Iterators that flatten the output into a series of paths
-
 def dir_paths(walk_iter):
-    """Iterate over just the directory names visited by the underlying walk
+    """Iterate over the directories visited by the underlying walk
+
+    Directories are emitted in the order visited, so the underlying walk may
+    be either top-down or bottom-up.
+    """
+    for dir_entry in walk_iter:
+        yield dir_entry[0]
+
+def all_dir_paths(walk_iter):
+    """Iterate over all directories reachable through the underlying walk
+
+    This covers:
+
+      * all visited directories (similar to dir_paths)
+      * all reported subdirectories of visited directories (even if not
+        otherwise visited)
+
+    Example cases where the output may differ from dir_paths:
+
+      * all_dir_paths always includes symlinks to directories even when the
+        underlying iterator doesn't follow symlinks
+      * all_dir_paths will include subdirectories of directories at the maximum
+        depth in a depth limited walk
 
     This iterator expects new root directories to be emitted by the underlying
-    walk before any of their contents, and hence requires a
-    top-down/breadth-first traversal of the directory hierarchy.
+    walk before any of their contents, and hence requires a top-down traversal
+    of the directory hierarchy.
     """
     dir_entry = next(walk_iter, None)
     if dir_entry is None:
@@ -339,17 +360,28 @@ def dir_paths(walk_iter):
         dir_entry = next(walk_iter, None)
 
 def file_paths(walk_iter):
-    """Iterate over the files in directories visited by the underlying walk"""
+    """Iterate over the files in directories visited by the underlying walk
+
+    Directory contents are emitted in the order visited, so the underlying walk
+    may be either top-down or bottom-up.
+    """
     for dir_entry in walk_iter:
         for fname in dir_entry[2]:
             yield os.path.join(dir_entry[0], fname)
 
 def all_paths(walk_iter):
-    """Iterate over both files and directories visited by the underlying walk
+    """Iterate over all paths reachable through the underlying walk
+
+    This covers:
+
+      * all visited directories
+      * all files in visited directories
+      * all reported subdirectories of visited directories (even if not
+        otherwise visited)
 
     This iterator expects new root directories to be emitted by the underlying
-    walk before any of their contents, and hence requires a
-    top-down/breadth-first traversal of the directory hierarchy.
+    walk before any of their contents, and hence requires a top-down traversal
+    of the directory hierarchy.
     """
     dir_entry = next(walk_iter, None)
     if dir_entry is None:


### PR DESCRIPTION
- dir_paths has been reverted to its 0.3 behaviour
- the new all_dir_paths API implements the new more
  inclusive semantics
- all_paths is now defined as the combination of the
  all_dir_paths and file_paths output
- also removed incorrect breadth-first/depth-first references
  noted in Issue #11
