### PR TITLE
Changed strings format to support python2.6

### DIFF
--- a/test_walkdir.py
+++ b/test_walkdir.py
@@ -370,11 +370,17 @@ class NoFilesystemTestCase(_BaseWalkTestCase):
     def test_limit_depth(self):
         self.assertWalkEqual(depth_0_tree, limit_depth(self.walk(), 0))
         self.assertWalkEqual(depth_1_tree, limit_depth(self.walk(), 1))
+        with self.assertRaises(ValueError) as cm:
+            next(limit_depth(self.walk(), -1))
+        self.assertIn("Depth limit less than 0", str(cm.exception))
 
     def test_min_depth(self):
         self.assertWalkEqual([], min_depth(self.walk(), 4))
         self.assertWalkEqual(expected_tree[1:], min_depth(self.walk(), 1))
         self.assertWalkEqual(min_depth_2_tree, min_depth(self.walk(), 2))
+        with self.assertRaises(ValueError) as cm:
+            next(min_depth(self.walk(), -1))
+        self.assertIn("Minimium depth less than 1", str(cm.exception))
 
     def test_include_dirs(self):
         self.assertWalkEqual(depth_0_tree, include_dirs(self.walk()))

--- a/walkdir.py
+++ b/walkdir.py
@@ -132,7 +132,7 @@ def limit_depth(walk_iter, depth):
     traversal of the directory hierarchy.
     """
     if depth < 0:
-        msg = "Depth limit less than 0 ({!r} provided)"
+        msg = "Depth limit less than 0 ({0!r} provided)"
         raise ValueError(msg.format(depth))
     sep=os.sep
     for dir_entry in walk_iter:
@@ -190,7 +190,7 @@ def min_depth(walk_iter, depth):
     traversal of the directory hierarchy.
     """
     if depth < 1:
-        msg = "Minimium depth less than 1 ({!r} provided)"
+        msg = "Minimium depth less than 1 ({0!r} provided)"
         raise ValueError(msg.format(depth))
     sep=os.sep
     for dir_entry in walk_iter:


### PR DESCRIPTION
I noticed that in `min_depth` and `limit_depth` we use format without index on the error messages we raise. This is not supported in python2.6 so I added the index and test's for this cases.
